### PR TITLE
Include required backend files for packaged application

### DIFF
--- a/preferences.py
+++ b/preferences.py
@@ -5,6 +5,7 @@ import keyring
 class Preferences:
 
     def __init__(self):
+        keyring.core.set_keyring(keyring.core.load_keyring('keyring.backends.OS_X.Keyring'))
         self.configuration = dict()
         self.filename = "configuration.json"
         self.read_config()


### PR DESCRIPTION
* Explicitly set the keyring so py2app picks up on the required backend files